### PR TITLE
Convert HTML tables to Markdown tables

### DIFF
--- a/_chapters/02.md
+++ b/_chapters/02.md
@@ -82,43 +82,15 @@ Traditional word embedding algorithms assign a distinct vector to each word. Thi
 
 Table 1 provides a directory of existing frameworks that are frequently used for creating embeddings which are further incorporated into deep learning models.
 
-<table>
-  <tr>
-    <th>Framework</th>
-    <th>Language</th>
-    <th>Url</th>
-  </tr>
-  <tr>
-    <td>S-Space</td>
-    <td>Java</td>
-    <td><a href="https://github.com/fozziethebeat/S-Space">https://github.com/fozziethebeat/S-Space</a></td>
-  </tr>
-  <tr>
-    <td>Semanticvectors</td>
-    <td>Java</td>
-    <td><a href="https://github.com/fozziethebeat/S-Space">https://github.com/semanticvectors/</a></td>
-  </tr>
-  <tr>
-    <td>Gensim</td>
-    <td>Python</td>
-    <td><a href="https://github.com/fozziethebeat/S-Space">https://radimrehurek.com/gensim/</a></td>
-  </tr>
-  <tr>
-    <td>Pydsm</td>
-    <td>Python</td>
-    <td><a href="https://github.com/fozziethebeat/S-Space">https://github.com/jimmycallin/pydsm</a></td>
-  </tr>
-  <tr>
-    <td>Dissect</td>
-    <td>Python</td>
-    <td><a href="https://github.com/fozziethebeat/S-Space">http://clic.cimec.unitn.it/composes/toolkit/</a></td>
-  </tr>
-  <tr>
-    <td>FastText</td>
-    <td>Python</td>
-    <td><a href="https://github.com/fozziethebeat/S-Space">https://fasttext.cc/</a></td>
-  </tr>
-</table>
+
+| Framework       | Language | URL                                                |
+|-----------------|----------|----------------------------------------------------|
+| S-Space         | Java     | https://github.com/fozziethebeat/S-Space           |
+| Semanticvectors | Java     | https://github.com/semanticvectors/semanticvectors |
+| Gensim          | Python   | https://radimrehurek.com/gensim/                   |
+| Pydsm           | Python   | https://github.com/jimmycallin/pydsm               |
+| Dissect         | Python   | http://clic.cimec.unitn.it/composes/toolkit/       |
+| FastText        | Python   | https://fasttext.cc/                               |
 
 *Table 1: Frameworks providing embedding tools and methods.*
 

--- a/_chapters/08.md
+++ b/_chapters/08.md
@@ -128,62 +128,16 @@ The Stanford Sentiment Treebank (SST) dataset contains sentences taken from the 
 
 [Kim (2014)](https://arxiv.org/abs/1408.5882) and [Kalchbrenner et al. ()](http://www.aclweb.org/anthology/P14-1062) both used convolutional layers. The model ([Kim, 2014](https://arxiv.org/abs/1408.5882)) was similar to the one in Figure 5, while [Kalchbrenner et al. ()](http://www.aclweb.org/anthology/P14-1062) constructed the model in a hierarchical manner by interweaving k-max pooling layers with convolutional layers. 
 
-<table>
-  <tr>
-    <th>Paper</th>
-    <th>Model</th>
-    <th><span style="font-weight:bold">SST-1</span></th>
-    <th><span style="font-weight:bold">SST-2</span></th>
-  </tr>
-  <tr>
-    <td><a href="https://nlp.stanford.edu/~socherr/EMNLP2013_RNTN.pdf">Socher et al. (2013)</a></td>
-    <td>Recursive Neural Tensor Network</td>
-    <td>45.7</td>
-    <td>85.4</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1408.5882">Kim (2014)</a></td>
-    <td>Multichannel CNN</td>
-    <td>47.4</td>
-    <td>88.1</td>
-  </tr>
-  <tr>
-    <td><a href="http://www.aclweb.org/anthology/P14-1062">Kalchbrenner et al. (2014)</a></td>
-    <td>DCNN with k-max pooling</td>
-    <td>48.5</td>
-    <td>86.8</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1503.00075">Tai et al. (2015)</a></td>
-    <td>Bidirectional LSTM</td>
-    <td>48.5</td>
-    <td>87.2</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1405.4053">Le and Mikolov (2014)</a></td>
-    <td>Paragraph Vector</td>
-    <td>48.7</td>
-    <td>87.8</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1503.00075">Tai et al. (2015)</a></td>
-    <td>Constituency Tree-LSTM</td>
-    <td>51.0</td>
-    <td>88.0</td>
-  </tr>
-  <tr>
-    <td><a href="https://www.aclweb.org/anthology/D17-1056">Yu et al. (2017)</a></td>
-    <td>Tree-LSTM with refined word embeddings</td>
-    <td>54.0</td>
-    <td>90.3</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1506.07285">Kumar et al. (2015)</a></td>
-    <td>DMN</td>
-    <td>52.1</td>
-    <td>88.6</td>
-  </tr>
-</table>
+| Paper                                                                        | Model                                  | SST-1 | SST-2 |
+|------------------------------------------------------------------------------|----------------------------------------|-------|-------|
+| [Socher et al. (2013)](https://nlp.stanford.edu/~socherr/EMNLP2013_RNTN.pdf) | Recursive Neural Tensor Network        | 45.7  | 85.4  |
+| [Kim (2014)](https://arxiv.org/abs/1408.5882)                                | Multichannel CNN                       | 47.4  | 88.1  |
+| [Kalchbrenner et al. (2014)](http://www.aclweb.org/anthology/P14-1062)       | DCNN with k-max pooling                | 48.5  | 86.8  |
+| [Tai et al. (2015)](https://arxiv.org/abs/1503.00075)                        | Bidirectional LSTM                     | 48.5  | 87.2  |
+| [Le and Mikolov (2014)](https://arxiv.org/abs/1405.4053)                     | Paragraph Vector                       | 48.7  | 87.8  |
+| [Tai et al. (2015)](https://arxiv.org/abs/1503.00075)                        | Constituency Tree-LSTM                 | 51.0  | 88.0  |
+| [Yu et al. (2017)](https://www.aclweb.org/anthology/D17-1056)                | Tree-LSTM with refined word embeddings | 54.0  | 90.3  |
+| [Kumar et al. (2015)](https://arxiv.org/abs/1506.07285)                      | DMN                                    | 52.1  | 88.6  |
 
 *Table 6: Sentiment Classification (SST-1 = Stanford Sentiment Treebank, fine-grained 5 classes [Socher et al. (2013)](https://nlp.stanford.edu/~socherr/EMNLP2013_RNTN.pdf); SST-2: the binary version of SST-1; Numbers are accuracies (%))*
 

--- a/_chapters/08.md
+++ b/_chapters/08.md
@@ -111,38 +111,12 @@ Traditional SRL systems consist of several stages: producing a parse tree, ident
 
 Given a predicate, [Täckström et al. (2015)](https://transacl.org/ojs/index.php/tacl/article/view/465/105) scored a constituent span and its possible role to that predicate with a series of features based on the parse tree. They proposed a dynamic programming algorithm for efficient inference. [Collobert et al. (2011)](http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf) achieved comparable results with a convolution neural networks augmented by parsing information provided in the form of additional look-up tables. [Zhou and Xu (2015)](http://www.aclweb.org/anthology/P15-1109) proposed to use bidirectional LSTM to model arbitrarily long context, which proved to be successful without any parsing tree information. [He et al. (2017)](https://aclanthology.coli.uni-saarland.de/papers/P17-1044/p17-1044) further extended this work by introducing highway connections ([Srivastava et al., 2015](https://papers.nips.cc/paper/5850-training-very-deep-networks.pdf)), more advanced regularization and ensemble of multiple experts.
 
-<table>
-  <tr>
-    <th>Paper</th>
-    <th>Model</th>
-    <th><span style="font-weight:bold">CoNLL2005 (F1 %)</span></th>
-    <th><span style="font-weight:bold">CoNLL2012 (F1 %)</span></th>
-  </tr>
-  <tr>
-    <td><a href="http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf">Collobert et al. (2011)</a></td>
-    <td>CNN with parsing features</td>
-    <td>76.06</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><a href="https://transacl.org/ojs/index.php/tacl/article/view/465/105">Täckström et al. (2015)</a></td>
-    <td>Manual features with DP for inference</td>
-    <td>78.6</td>
-    <td>79.4</td>
-  </tr>
-  <tr>
-    <td><a href="http://www.aclweb.org/anthology/P15-1109">Zhou and Xu (2015)</a></td>
-    <td>Bidirectional LSTM</td>
-    <td>81.07</td>
-    <td>81.27</td>
-  </tr>
-  <tr>
-    <td><a href="https://aclanthology.coli.uni-saarland.de/papers/P17-1044/p17-1044">He et al. (2017)</a></td>
-    <td>Bidirectional LSTM with highway connections</td>
-    <td>83.2</td>
-    <td>83.4</td>
-  </tr>
-</table>
+| Paper                                                                                        | Model                                       | CoNLL 2005 (F1 %) | CoNLL 2012 (F1 %) |
+|----------------------------------------------------------------------------------------------|---------------------------------------------|-------------------|-------------------|
+| [Collobert et al. (2011)](http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf) | CNN with parsing features                   | 76.06             |                   |
+| [Täckström et al. (2015)](https://transacl.org/ojs/index.php/tacl/article/view/465/105)      | Manual features with DP for inference       | 78.60             | 79.40             |
+| [Zhou and Xu (2015)](http://www.aclweb.org/anthology/P15-1109)                               | Bidirectional LSTM                          | 81.07             | 81.27             |
+| [He et al. (2017)](https://aclanthology.coli.uni-saarland.de/papers/P17-1044/p17-1044)       | Bidirectional LSTM with highway connections | 83.20             | 83.40             |
 
 *Table 5: Semantic Role Labeling*
 

--- a/_chapters/08.md
+++ b/_chapters/08.md
@@ -165,44 +165,13 @@ The central problem of learning to answer single-relation queries is to find the
 
 For models on the *SQuAD* dataset, the goal is to determine the start point and end point of the answer segment. [Chen et al. (2017)](https://arxiv.org/abs/1704.00051) encoded both the question and the words in context using LSTMs and used a bilinear matrix for calculating the similarity between the two. [Shen et al. (2017)](https://arxiv.org/abs/1609.05284) proposed Reasonet, a model that read a document repeatedly with attention on different parts each time until a satisfying answer is found. [Yu et al., 2018](https://arxiv.org/abs/1804.09541) replaced RNNs with convolution and self-attention for encoding the question and the context with significant speed improvement.
 
-<table>
-  <tr>
-    <th>Paper</th>
-    <th>Model</th>
-    <th><span style="font-weight:bold">bAbI (Mean accuracy %)</span></th>
-    <th><span style="font-weight:bold">Farbes (Accuracy %)</span></th>
-  </tr>
-  <tr>
-    <td><a href="http://www.aclweb.org/anthology/P13-1158">Fader et al. (2013)</a></td>
-    <td>Paraphrase-driven lexicon learning</td>
-    <td></td>
-    <td>0.54</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1404.4326">Bordes et al. (2014)</a></td>
-    <td>Weekly supervised embedding</td>
-    <td></td>
-    <td>0.73</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1410.3916">Weston et al. (2014)</a></td>
-    <td>Memory networks</td>
-    <td>93.3</td>
-    <td>0.83</td>
-  </tr>
-  <tr>
-    <td><a href="https://papers.nips.cc/paper/5846-end-to-end-memory-networks.pdf">Sukhbaatar et al. (2015)</a></td>
-    <td>End-to-end memory networks</td>
-    <td>88.4</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1506.07285">Kumar et al. (2015)</a></td>
-    <td>DMN</td>
-    <td>93.6</td>
-    <td></td>
-  </tr>
-</table>
+| Paper                                                                                        | Model                              | bAbI (Mean accuracy %) | Farbes (Accuracy %) |
+|----------------------------------------------------------------------------------------------|------------------------------------|------------------------|---------------------|
+| [Fader et al. (2013)](http://www.aclweb.org/anthology/P13-1158)                              | Paraphrase-driven lexicon learning |                        | 0.54                |
+| [Bordes et al. (2014)](https://arxiv.org/abs/1404.4326)                                      | Weekly supervised embedding        |                        | 0.73                |
+| [Weston et al. (2014)](https://arxiv.org/abs/1410.3916)                                      | Memory networks                    | 93.3                   | 0.93                |
+| [Sukhbaatar et al. (2015)](https://papers.nips.cc/paper/5846-end-to-end-memory-networks.pdf) | End-to-end memory networks         | 88.4                   |                     |
+| [Kumar et al. (2015)](https://arxiv.org/abs/1506.07285)                                      | DMN                                | 93.6                   |                     |
 
 *Table 8: Question answering*
 

--- a/_chapters/08.md
+++ b/_chapters/08.md
@@ -32,58 +32,23 @@ There are two types of parsing: dependency parsing, which connects individual wo
 
 Transition-based models were applied to constituency parsing as well. [Zhu et al. (2013)](http://www.aclweb.org/anthology/P13-1043.pdf) based each transition action on features such as the POS tags and constituent labels of the top few words of the stack and the buffer. By uniquely representing the parsing tree with a linear sequence of labels, [Vinyals et al. (2015)](https://papers.nips.cc/paper/5635-grammar-as-a-foreign-language.pdf) applied the seq2seq learning method to this problem.
 
-<table>
-  <tr>
-    <th>Parsing type</th>
-    <th>Paper</th>
-    <th>Model</th>
-    <th><span style="font-weight:bold">WSJ</span></th>
-  </tr>
-  <tr>
-    <td rowspan="4"><br><br><br><br>Dependency<br>Parsing</td>
-    <td><a href="https://aclanthology.coli.uni-saarland.de/papers/D14-1082/d14-1082">Chen and Manning (2014)</a></td>
-    <td>Fully-connected NN with features including POS</td>
-    <td>91.8/89.6 (UAS/LAS)</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1506.06158">Weiss et al. (2015)</a></td>
-    <td>Deep fully-connected NN with features including POS</td>
-    <td>94.3/92.4 (UAS/LAS)</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1505.08075">Dyer et al. (2015)</a></td>
-    <td>Stack-LSTM</td>
-    <td>93.1/90.9 (UAS/LAS)</td>
-  </tr>
-  <tr>
-    <td><a href="https://jair.org/index.php/jair/article/view/11054">Zhou et al. (2017)</a></td>
-    <td>Beam contrastive model</td>
-    <td>93.31/92.37 (UAS/LAS)</td>
-  </tr>
-  <tr>
-    <td rowspan="4"><br><br><br><br>Constituency<br>Parsing</td>
-    <td><a href="https://pdfs.semanticscholar.org/d84b/9507ff9687a900fde451f27106d930c1b838.pdf">Petrov et al. (2006)</a></td>
-    <td>Probabilistic context-free grammars (PCFG)</td>
-    <td>91.8 (F1 Score)</td>
-  </tr>
-  <tr>
-    <td><a href="https://ai.stanford.edu/~ang/papers/icml11-ParsingWithRecursiveNeuralNetworks.pdf">Socher et al. (2011)</a></td>
-    <td>Recursive neural networks</td>
-    <td>90.29 (F1 Score)</td>
-  </tr>
-  <tr>
-    <td><a href="http://www.aclweb.org/anthology/P13-1043.pdf">Zhu et al. (2013)</a></td>
-    <td>Feature-based transition parsing</td>
-    <td>91.3 (F1 Score)</td>
-  </tr>
-  <tr>
-    <td><a href="https://papers.nips.cc/paper/5635-grammar-as-a-foreign-language.pdf">Vinyals et al. (2015)</a></td>
-    <td>seq2seq learning with LSTM+Attention</td>
-    <td>93.5 (F1 Score)</td>
-  </tr>
-</table>
+| Paper                                                                                         | Model                                               | WSJ (UAS/LAS) |
+|-----------------------------------------------------------------------------------------------|-----------------------------------------------------|---------------|
+| [Chen and Manning (2014)](https://aclanthology.coli.uni-saarland.de/papers/D14-1082/d14-1082) | Fully-connected NN with features including POS      | 91.80/89.60   |
+| [Weiss et al. (2015)](https://arxiv.org/abs/1506.06158)                                       | Deep fully-connected NN with features including POS | 94.30/92.40   |
+| [Dyer et al. (2015)](https://arxiv.org/abs/1505.08075)                                        | Stack-LSTM                                          | 93.10/90.90   |
+| [Zhou et al. (2017)](https://jair.org/index.php/jair/article/view/11054)                      | Beam contrastive model                              | 93.31/92.37   |
 
-*Table 3: Parsing (UAS/LAS = Unlabeled/labeled Attachment Score; WSJ = The Wall Street Journal Section of Penn Treebank)*
+*Table 3.1: Dependency Parsing (UAS/LAS = Unlabeled/labeled Attachment Score; WSJ = The Wall Street Journal Section of Penn Treebank)*
+
+| Paper                                                                                                     | Model                                      | WSJ (F1 %) |
+|-----------------------------------------------------------------------------------------------------------|--------------------------------------------|------------|
+| [Petrov et al. (2006)](https://pdfs.semanticscholar.org/d84b/9507ff9687a900fde451f27106d930c1b838.pdf)    | Probabilistic context-free grammars (PCFG) | 91.80      |
+| [Socher et al. (2011)](https://ai.stanford.edu/~ang/papers/icml11-ParsingWithRecursiveNeuralNetworks.pdf) | Recursive neural networks                  | 90.29      |
+| [Zhu et al. (2013)](http://www.aclweb.org/anthology/P13-1043.pdf)                                         | Feature-based transition parsing           | 91.30      |
+| [Vinyals et al. (2015)](https://papers.nips.cc/paper/5635-grammar-as-a-foreign-language.pdf)              | seq2seq learning with LSTM+Attention       | 93.50      |
+
+*Table 3.2: Constituency Parsing*
 
 ## C. Named-Entity Recognition
 

--- a/_chapters/08.md
+++ b/_chapters/08.md
@@ -10,58 +10,17 @@ We summarize the performance of a series of deep learning methods on standard da
 The WSJ-PTB (the Wall Street Journal part of the Penn Treebank Dataset) corpus contains 1.17 million tokens and has been widely used for developing and evaluating POS tagging systems. [Giménez and Marquez (2004)](https://pdfs.semanticscholar.org/f7ac/2682ace56c752c60868312e5eeeef0d96a41.pdf) employed one-against-all SVM based on manually-defined features within a seven-word window, in which some basic n-gram patterns were evaluated to form binary features such as: "previous word is *the*", "two preceding tags are DT NN", etc. One characteristic of the POS tagging problem was the strong dependency between adjacent tags. With a simple left-to-right tagging scheme, this method modeled dependencies between adjacent tags only by feature engineering. In an effort to reduce feature engineering, [Collobert et al. (2011)](http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf) relied on only word embeddings within the word window by a multi-layer perceptron. Incorporating CRF was proven useful in ([Collobert et al., 2011](http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf)). 
 [Santos and Zadrozny (2014)](http://proceedings.mlr.press/v32/santos14.pdf) concatenated word embeddings with character embeddings to better exploit morphological clues. In ([Santos and Zadrozny, 2014](http://proceedings.mlr.press/v32/santos14.pdf)), the authors did not consider CRF, but since word-level decision was made on a context window, it can be seen that dependencies were modeled implicitly. [Huang et al. (2015)](https://arxiv.org/abs/1508.01991) concatenated word embeddings and manually-designed word-level features and employed bidirectional LSTM to model arbitrarily long context. A series of ablative analysis suggested that bi-directionality and CRF both boosted performance. [Andor et al. (2016)](https://arxiv.org/abs/1603.06042) showed a transition-based approach that produces competitive result with a simple feed-forward neural network. When applied to sequence tagging tasks, DMNs ([Kumar et al., 2015](https://arxiv.org/abs/1506.07285)) essentially allowed for attending over the context multiple times by treating each RNN hidden state as a memory entry, each time focusing on different parts of the context. 
 
-<table>
-  <tr>
-    <th>Paper</th>
-    <th>Model</th>
-    <th>WSJ-PTB (per-token accuracy %)</th>
-  </tr>
-  <tr>
-    <td><a href="https://pdfs.semanticscholar.org/f7ac/2682ace56c752c60868312e5eeeef0d96a41.pdf">Giménez and Marquez (2004)</a></td>
-    <td>SVM with manual feature pattern</td>
-    <td>97.16</td>
-  </tr>
-  <tr>
-    <td><a href="http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf">Collobert et al. (2011).</a></td>
-    <td>MLP with word embeddings + CRF</td>
-    <td>97.29</td>
-  </tr>
-  <tr>
-    <td><a href="http://proceedings.mlr.press/v32/santos14.pdf">Santos and Zadrozny (2014)</a></td>
-    <td>MLP with character+word embeddings</td>
-    <td>97.32</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1508.01991">Huang et al. (2015)</a></td>
-    <td>LSTM</td>
-    <td>97.29</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1508.01991">Huang et al. (2015)</a></td>
-    <td>Bidirectional LSTM</td>
-    <td>97.40</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1508.01991">Huang et al. (2015)</a></td>
-    <td>LSTM-CRF</td>
-    <td>97.54</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1508.01991">Huang et al. (2015)</a></td>
-    <td>Bidirectional LSTM-CRF</td>
-    <td>97.55</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1603.06042">Andor et al. (2016)</a></td>
-    <td>Transition-based neural network</td>
-    <td>97.45</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1506.07285">Kumar et al. (2015)</a></td>
-    <td>DMN</td>
-    <td>97.56</td>
-  </tr>
-</table>
+| Paper                                                                                                        | Model                              | WSJ-PTB (per-token accuracy %) |
+|--------------------------------------------------------------------------------------------------------------|------------------------------------|--------------------------------|
+| [Giménez and Marquez (2004)](https://pdfs.semanticscholar.org/f7ac/2682ace56c752c60868312e5eeeef0d96a41.pdf) | SVM with manual feature pattern    | 97.16                          |
+| [Collobert et al. (2011)](http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf)                 | MLP with word embeddings + CRF     | 97.29                          |
+| [Santos and Zadrozny (2014)](http://proceedings.mlr.press/v32/santos14.pdf)                                  | MLP with character+word embeddings | 97.32                          |
+| [Huang et al. (2015)](https://arxiv.org/abs/1508.01991)                                                      | LSTM                               | 97.29                          |
+| [Huang et al. (2015)](https://arxiv.org/abs/1508.01991)                                                      | Bidirectional LSTM                 | 97.40                          |
+| [Huang et al. (2015)](https://arxiv.org/abs/1508.01991)                                                      | LSTM-CRF                           | 97.54                          |
+| [Huang et al. (2015)](https://arxiv.org/abs/1508.01991)                                                      | Bidirectional LSTM-CRF             | 97.55                          |
+| [Andor et al. (2016)](https://arxiv.org/abs/1603.06042)                                                      | Transition-based neural network    | 97.45                          |
+| [Kumar et al. (2015)](https://arxiv.org/abs/1506.07285)                                                      | DMN                                | 97.56                          |
 
 *Table 2: POS tagging*
 

--- a/_chapters/08.md
+++ b/_chapters/08.md
@@ -145,44 +145,13 @@ The Stanford Sentiment Treebank (SST) dataset contains sentences taken from the 
 
 The phrase-based SMT framework ([Koehn et al., 2003](http://www.aclweb.org/anthology/N03-1017)) factorized the translation model into the translation probabilities of matching phrases in the source and target sentences. [Cho et al. (2014)](https://arxiv.org/abs/1406.1078) proposed to learn the translation probability of a source phrase to a corresponding target phrase with an RNN encoder-decoder. Such a scheme of scoring phrase pairs improved translation performance. [Sutskever et al. (2014)](https://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-networks.pdf), on the other hand, re-scored the top 1000 best candidate translations produced by an SMT system with a 4-layer LSTM seq2seq model. Dispensing the traditional SMT system entirely, [Wu et al. (2016)](https://arxiv.org/abs/1609.08144) trained a deep LSTM network with 8 encoder and 8 decoder layers with residual connections as well as attention connections. ([Wu et al., 2016](https://arxiv.org/abs/1609.08144)) then refined the model by using reinforcement learning to directly optimize BLEU scores, but they found that the improvement in BLEU scores by this method did not reflect in human evaluation of translation quality. Recently, [Gehring et al. (2017)](https://arxiv.org/abs/1705.03122) proposed a CNN-based seq2seq learning model for machine translation. The representation for each word in the input is computed by CNN in a parallelized style for the attention mechanism. The decoder state is also determined by CNN with words that are already produced. [Vaswani et al. (2017)](https://arxiv.org/abs/1706.03762) proposed a self-attention-based model and dispensed convolutions and recurrences entirely.
 
-<table>
-  <tr>
-    <th>Paper</th>
-    <th>Model</th>
-    <th><span style="font-weight:bold">WMT2014 English2German</span></th>
-    <th><span style="font-weight:bold">WMT2014 English2French</span></th>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1406.1078">Cho et al. (2014)</a></td>
-    <td>Phrase table with neural features</td>
-    <td></td>
-    <td>34.50</td>
-  </tr>
-  <tr>
-    <td><a href="https://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-networks.pdf">Sutskever et al. (2014)</a></td>
-    <td>Reranking phrase-based SMT best list with LSTM seq2seq</td>
-    <td></td>
-    <td>36.5</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1609.08144">Wu et al. (2016)</a></td>
-    <td>Residual LSTM seq2seq + Reinforcement learning refining</td>
-    <td>26.30</td>
-    <td>41.16</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1705.03122">Gehring et al. (2017)</a></td>
-    <td>seq2seq with CNN</td>
-    <td>26.36</td>
-    <td>41.29</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1706.03762">Vaswani et al. (2017)</a></td>
-    <td>Attention mechanism</td>
-    <td>28.4</td>
-    <td>41.0</td>
-  </tr>
-</table>
+| Paper                                                                                                               | Model                                                   | WMT2014 English2German | WMT2014 English2French |
+|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|------------------------|------------------------|
+| [Cho et al. (2014)](https://arxiv.org/abs/1406.1078)                                                                | Phrase table with neural features                       |                        | 34.50                  |
+| [Sutskever et al. (2014)](https://papers.nips.cc/paper/5346-sequence-to-sequence-learning-with-neural-networks.pdf) | Reranking phrase-based SMT best list with LSTM seq2seq  |                        | 36.50                  |
+| [Wu et al. (2016)](https://arxiv.org/abs/1609.08144)                                                                | Residual LSTM seq2seq + Reinforcement learning refining | 26.30                  | 41.16                  |
+| [Gehring et al. (2017)](https://arxiv.org/abs/1705.03122)                                                           | seq2seq with CNN                                        | 26.36                  | 41.29                  |
+| [Vaswani et al. (2017)](https://arxiv.org/abs/1706.03762)                                                           | Attention mechanism                                     | 28.40                  | 41.00                  |
 
 *Table 7: Machine translation (Numbers are BLEU scores)*
 

--- a/_chapters/08.md
+++ b/_chapters/08.md
@@ -91,48 +91,15 @@ CoNLL 2003 has been a standard English dataset for NER, which concentrates on fo
 
 [Passos et al. (2014)](http://www.aclweb.org/anthology/W14-1609) proposed to modify skip-gram models to better learn entity-type related word embeddings that can leverage information from relevant lexicons. [Luo et al. (2015)](http://www.aclweb.org/anthology/D15-1104) jointly optimized the entities and the linking of entities to a KB. [Strubell et al. (2017)](https://arxiv.org/abs/1702.02098) proposed to use dilated convolutions, defined over a wider effective input width by skipping over certain inputs at a time, for better parallelization and context modeling. The model showed significant speedup while retaining accuracy.  
 
-<table>
-  <tr>
-    <th>Paper</th>
-    <th>Model</th>
-    <th><span style="font-weight:bold">CoNLL 2003 (F1 %)</span></th>
-  </tr>
-  <tr>
-    <td><a href="http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf">Collobert et al. (2011)</a></td>
-    <td>MLP with word embeddings+gazetteer</td>
-    <td>89.59</td>
-  </tr>
-  <tr>
-    <td><a href="http://www.aclweb.org/anthology/W14-1609">Passos et al. (2014)</a></td>
-    <td>Lexicon Infused Phrase Embeddings</td>
-    <td>90.90</td>
-  </tr>
-  <tr>
-    <td><a href="https://www.aclweb.org/anthology/Q16-1026">Chiu and Nichols (2015)</a></td>
-    <td>Bi-LSTM with word+char+lexicon embeddings</td>
-    <td>90.77</td>
-  </tr>
-  <tr>
-    <td><a href="http://www.aclweb.org/anthology/D15-1104">Luo et al. (2015)</a></td>
-    <td>Semi-CRF jointly trained with linking</td>
-    <td>91.20</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1603.01360">Lample et al. (2016)</a></td>
-    <td>Bi-LSTM-CRF with word+char embeddings</td>
-    <td>90.94</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1603.01360">Lample et al. (2016)</a></td>
-    <td>Bi-LSTM with word+char embeddings</td>
-    <td>89.15</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1702.02098">Strubell et al. (2017)</a></td>
-    <td>Dilated CNN with CRF</td>
-    <td>90.54</td>
-  </tr>
-</table>
+| Paper                                                                                        | Model                                     | CoNLL 2003 (F1 %) |
+|----------------------------------------------------------------------------------------------|-------------------------------------------|-------------------|
+| [Collobert et al. (2011)](http://www.jmlr.org/papers/volume12/collobert11a/collobert11a.pdf) | MLP with word embeddings+gazetteer        | 89.59             |
+| [Passos et al. (2014)](http://www.aclweb.org/anthology/W14-1609)                             | Lexicon Infused Phrase Embeddings         | 90.90             |
+| [Chiu and Nichols (2015)](https://www.aclweb.org/anthology/Q16-1026)                         | Bi-LSTM with word+char+lexicon embeddings | 90.77             |
+| [Luo et al. (2015)](http://www.aclweb.org/anthology/D15-1104)                                | Semi-CRF jointly trained with linking     | 91.20             |
+| [Lample et al. (2016)](https://arxiv.org/abs/1603.01360)                                     | Bi-LSTM with word+char embeddings         | 89.15             |
+| [Lample et al. (2016)](https://arxiv.org/abs/1603.01360)                                     | Bi-LSTM-CRF with word+char embeddings     | 90.94             |
+| [Strubell et al. (2017)](https://arxiv.org/abs/1702.02098)                                   | Dilated CNN with CRF                      | 90.54             |
 
 *Table 4: Named-Entity Recognition*
 

--- a/_chapters/08.md
+++ b/_chapters/08.md
@@ -185,55 +185,14 @@ The response retrieval task is defined as selecting the best response from a rep
 
 [Zhou et al. (2016)](http://www.aclweb.org/anthology/D16-1036) proposed to better exploit the multi-turn nature of human conversation by employing the LSTM encoder on top of sentence-level CNN embeddings, similar to ([Serban et al., 2016](https://arxiv.org/abs/1507.04808)). [Dodge et al. (2015)](https://arxiv.org/abs/1511.06931) cast the problem in the framework of a memory network, where the past conversation was treated as memory and the latest utterance was considered as a "question" to be responded to. The authors showed that using simple neural bag-of-word embedding for sentences can yield competitive results.
 
-<table>
-  <tr>
-    <th>Paper</th>
-    <th>Model</th>
-    <th><span style="font-weight:bold">Twitter Conversation</span><br><span style="font-weight:bold">Triple Dataset (BLEU)</span></th>
-    <th><span style="font-weight:bold">Ubuntu Dialogue</span><br><span style="font-weight:bold">Dataset (recall 1@10 %)</span></th>
-  </tr>
-  <tr>
-    <td><a href="http://www.aclweb.org/anthology/D11-1054">Ritter et al. (2011)</a></td>
-    <td>SMT</td>
-    <td>3.60</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1506.06714">Sordoni et al. (2015)</a></td>
-    <td>SMT+neural reranking</td>
-    <td>4.44</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1510.03055">Li et al. (2015)</a></td>
-    <td>LSTM seq2seq</td>
-    <td>4.51</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1510.03055">Li et al. (2015)</a></td>
-    <td>LSTM seq2seq with MMI objective</td>
-    <td>5.22</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1506.08909">Lowe et al. (2015)</a></td>
-    <td>Dual LSTM encoders for semantic matching</td>
-    <td></td>
-    <td>55.22</td>
-  </tr>
-  <tr>
-    <td><a href="https://arxiv.org/abs/1511.06931">Dodge et al. (2015)</a></td>
-    <td>Memory networks</td>
-    <td></td>
-    <td>63.72</td>
-  </tr>
-  <tr>
-    <td><a href="http://www.aclweb.org/anthology/D16-1036">Zhou et al. (2016)</a></td>
-    <td>Sentence-level CNN-LSTM encoder</td>
-    <td></td>
-    <td>66.15</td>
-  </tr>
-</table>
+| Paper                                                            | Model                                    | Twitter Conversation Triple Dataset (BLEU) | Ubuntu Dialogue Dataset (recall 1@10 %) |
+|------------------------------------------------------------------|------------------------------------------|--------------------------------------------|-----------------------------------------|
+| [Ritter et al. (2011)](http://www.aclweb.org/anthology/D11-1054) | SMT                                      | 3.60                                       |                                         |
+| [Sordoni et al. (2015)](https://arxiv.org/abs/1506.06714)        | SMT+neural reranking                     | 4.44                                       |                                         |
+| [Li et al. (2015)](https://arxiv.org/abs/1510.03055)             | LSTM seq2seq                             | 4.51                                       |                                         |
+| [Li et al. (2015)](https://arxiv.org/abs/1510.03055)             | LSTM seq2seq with MMI objective          | 5.22                                       |                                         |
+| [Lowe et al. (2015)](https://arxiv.org/abs/1506.08909)           | Dual LSTM encoders for semantic matching |                                            | 55.22                                   |
+| [Dodge et al. (2015)](https://arxiv.org/abs/1511.06931)          | Memory networks                          |                                            | 63.72                                   |
+| [Zhou et al. (2016)](http://www.aclweb.org/anthology/D16-1036)   | Sentence-level CNN-LSTM encoder          |                                            | 66.15                                   |
 
 *Table 9: Dialogue systems*


### PR DESCRIPTION
I'm converting HTML tables to markdown following kramdown [specifications](https://kramdown.gettalong.org/syntax.html#tables), as suggested in #1.

I still haven't converted table 3 because the HTML version contains multi-line cells, which kramdown doesn't support. Should we keep the HTML version? or perhaps separate that table into 2 separate tables, one for dependency parsing, and another for constituency parsing?